### PR TITLE
Refactor game utilities and add automated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+node_modules/
+.DS_Store
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Coverage directories
+coverage/
+
+# Environment files
+.env
+.env.*

--- a/__tests__/game-utils.test.js
+++ b/__tests__/game-utils.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { clamp, collides, createStarfield, advanceFloatingTexts } from '../game-utils.js';
+
+test('clamp limits values within the provided range', () => {
+  assert.equal(clamp(10, 0, 5), 5);
+  assert.equal(clamp(-4, -2, 8), -2);
+  assert.equal(clamp(3, 0, 10), 3);
+});
+
+test('clamp throws when arguments are invalid', () => {
+  assert.throws(() => clamp('3', 0, 5), TypeError);
+  assert.throws(() => clamp(3, 6, 2), RangeError);
+});
+
+test('collides detects intersections between a circle and a rectangle', () => {
+  const rect = { x: 100, y: 100, width: 50, height: 20 };
+  const circle = { x: 110, y: 105, radius: 15 };
+  assert.equal(collides(circle, rect), true);
+});
+
+test('collides returns false when objects do not overlap', () => {
+  const rect = { x: 100, y: 100, width: 50, height: 20 };
+  const circle = { x: 200, y: 200, radius: 10 };
+  assert.equal(collides(circle, rect), false);
+});
+
+test('createStarfield creates stars using deterministic randomness', () => {
+  const values = [
+    0.1, 0.2, 0.3, 0.4, 0.9, 0.5, 0.6, 0.7,
+    0.9, 0.8, 0.7, 0.6, 0.3, 0.2, 0.1, 0.0,
+  ];
+  let index = 0;
+  const random = () => {
+    const value = values[index % values.length];
+    index += 1;
+    return value;
+  };
+
+  const stars = createStarfield(2, 200, 100, random);
+  assert.equal(stars.length, 2);
+
+  const [first, second] = stars;
+
+  assert.deepEqual(
+    { x: first.x, y: first.y, color: first.color },
+    { x: 20, y: 20, color: '#9be7ff' },
+  );
+  assert.ok(Math.abs(first.size - (0.3 * 2 + 0.5)) < 1e-6);
+  assert.ok(Math.abs(first.speed - (25 + 0.4 * 60)) < 1e-6);
+  assert.ok(Math.abs(first.opacity - (0.4 + 0.5 * 0.6)) < 1e-6);
+  assert.ok(Math.abs(first.swing - 0.6 * 0.8) < 1e-6);
+  assert.ok(Math.abs(first.offset - 0.7 * Math.PI * 2) < 1e-6);
+
+  assert.equal(second.color, '#e0c3ff');
+  assert.ok(Math.abs(second.x - 0.9 * 200) < 1e-6);
+  assert.ok(Math.abs(second.y - 0.8 * 100) < 1e-6);
+  assert.ok(Math.abs(second.size - (0.7 * 2 + 0.5)) < 1e-6);
+  assert.ok(Math.abs(second.speed - (25 + 0.6 * 60)) < 1e-6);
+});
+
+test('createStarfield validates input arguments', () => {
+  assert.throws(() => createStarfield(-1, 100, 100), RangeError);
+  assert.throws(() => createStarfield(1, '100', 100), TypeError);
+});
+
+test('advanceFloatingTexts updates entries and prunes expired ones', () => {
+  const entries = [
+    { text: 'A', x: 0, y: 10, color: '#fff', life: 1 },
+    { text: 'B', x: 0, y: 5, color: '#fff', life: 0.1 },
+  ];
+
+  advanceFloatingTexts(entries, 0.2);
+
+  assert.equal(entries.length, 1);
+  assert.ok(Math.abs(entries[0].y - (10 - 0.2 * 40)) < 1e-6);
+  assert.ok(Math.abs(entries[0].life - 0.8) < 1e-6);
+});
+
+test('advanceFloatingTexts throws when called with invalid arguments', () => {
+  assert.throws(() => advanceFloatingTexts({}, 0.16), TypeError);
+  assert.throws(() => advanceFloatingTexts([], Number.NaN), TypeError);
+});

--- a/game-utils.js
+++ b/game-utils.js
@@ -1,0 +1,65 @@
+export function clamp(value, min, max) {
+  if (typeof value !== 'number' || typeof min !== 'number' || typeof max !== 'number') {
+    throw new TypeError('clamp expects numeric arguments');
+  }
+  if (min > max) {
+    throw new RangeError('clamp min cannot be greater than max');
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
+export function collides(circle, rect) {
+  const { x: cx, y: cy, radius } = circle;
+  const { x: rx, y: ry, width, height } = rect;
+
+  const halfWidth = width / 2;
+  const halfHeight = height / 2;
+
+  const closestX = clamp(cx, rx - halfWidth, rx + halfWidth);
+  const closestY = clamp(cy, ry - halfHeight, ry + halfHeight);
+
+  const dx = cx - closestX;
+  const dy = cy - closestY;
+  return dx * dx + dy * dy <= radius * radius;
+}
+
+export function createStarfield(count, width, height, random = Math.random) {
+  if (!Number.isInteger(count) || count < 0) {
+    throw new RangeError('count must be a non-negative integer');
+  }
+  if (typeof width !== 'number' || typeof height !== 'number') {
+    throw new TypeError('width and height must be numbers');
+  }
+  const stars = [];
+  for (let i = 0; i < count; i += 1) {
+    stars.push({
+      x: random() * width,
+      y: random() * height,
+      size: random() * 2 + 0.5,
+      speed: 25 + random() * 60,
+      color: random() > 0.4 ? '#9be7ff' : '#e0c3ff',
+      opacity: 0.4 + random() * 0.6,
+      swing: random() * 0.8,
+      offset: random() * Math.PI * 2,
+    });
+  }
+  return stars;
+}
+
+export function advanceFloatingTexts(entries, delta) {
+  if (!Array.isArray(entries)) {
+    throw new TypeError('entries must be an array');
+  }
+  if (typeof delta !== 'number' || Number.isNaN(delta)) {
+    throw new TypeError('delta must be a number');
+  }
+
+  for (let i = entries.length - 1; i >= 0; i -= 1) {
+    const entry = entries[i];
+    entry.y -= delta * 40;
+    entry.life -= delta;
+    if (entry.life <= 0) {
+      entries.splice(i, 1);
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>流星追光者</title>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="game-wrapper">
+      <header class="panel">
+        <h1>流星追光者</h1>
+        <p>
+          操控你的追光者，收集墜落的星光並躲避危險的暗物質。累積分數解鎖
+          更刺激的速度，偶爾還會有護盾祝福幫你渡過危機！
+        </p>
+        <button id="startButton" class="primary">開始遊戲</button>
+      </header>
+      <main class="game-area">
+        <canvas id="game" width="900" height="600" aria-label="遊戲畫布"></canvas>
+        <section id="hud" class="hud" aria-live="polite">
+          <div>分數：<span id="score">0</span></div>
+          <div>等級：<span id="level">1</span></div>
+          <div>生命：<span id="lives">3</span></div>
+          <div>最高分：<span id="best">0</span></div>
+        </section>
+        <section id="message" class="message" role="status"></section>
+      </main>
+      <aside class="panel tips">
+        <h2>玩法提示</h2>
+        <ul>
+          <li>使用 ← → 方向鍵（或 A / D）移動。</li>
+          <li>按空白鍵啟動短時間的<span class="emphasis">閃避疾跑</span>。</li>
+          <li>收集金色星光獲得 10 分，銀色星光獲得 20 分。</li>
+          <li>紅色暗物質會奪走一點生命，除非你戴著護盾。</li>
+          <li>捕捉藍色護盾球，可獲得 5 秒的保護力場。</li>
+        </ul>
+        <p>挑戰更高分數，寫下屬於你的星際冒險！</p>
+      </aside>
+    </div>
+    <script type="module" src="script.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sal-yaakov-game",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,599 @@
+import { clamp, collides, createStarfield, advanceFloatingTexts } from './game-utils.js';
+
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+const startButton = document.getElementById('startButton');
+const scoreEl = document.getElementById('score');
+const levelEl = document.getElementById('level');
+const livesEl = document.getElementById('lives');
+const bestEl = document.getElementById('best');
+const messageEl = document.getElementById('message');
+
+const player = {
+  x: canvas.width / 2,
+  y: canvas.height - 90,
+  width: 90,
+  height: 26,
+  baseSpeed: 360,
+  dashMultiplier: 1.85,
+  dashTime: 0,
+  dashCooldown: 0,
+  shieldTime: 0,
+  trail: [],
+};
+
+const controls = {
+  left: false,
+  right: false,
+};
+
+const items = [];
+const floatingTexts = [];
+const particles = [];
+const starfield = createStarfield(70, canvas.width, canvas.height);
+
+const state = {
+  playing: false,
+  gameOver: false,
+  score: 0,
+  lives: 3,
+  level: 1,
+  spawnTimer: 0,
+  highScore: 0,
+  newHighScoreThisRun: false,
+};
+
+const STORAGE_KEY = 'meteor-chaser-best-score';
+let messageTimer = null;
+let storageAvailable = false;
+
+init();
+requestAnimationFrame(loop);
+
+function init() {
+  try {
+    const stored = Number(localStorage.getItem(STORAGE_KEY));
+    if (!Number.isNaN(stored)) {
+      state.highScore = stored;
+      bestEl.textContent = stored;
+    }
+    storageAvailable = true;
+  } catch (error) {
+    storageAvailable = false;
+  }
+
+  startButton.addEventListener('click', () => {
+    if (!state.playing) {
+      startGame();
+    }
+  });
+
+  window.addEventListener('keydown', (event) => {
+    if (event.repeat) return;
+    switch (event.code) {
+      case 'ArrowLeft':
+      case 'KeyA':
+        controls.left = true;
+        break;
+      case 'ArrowRight':
+      case 'KeyD':
+        controls.right = true;
+        break;
+      case 'Space':
+        if (state.playing) {
+          event.preventDefault();
+          dash();
+        }
+        break;
+      case 'Enter':
+        if (state.gameOver) {
+          startGame();
+        }
+        break;
+      default:
+        break;
+    }
+  });
+
+  window.addEventListener('keyup', (event) => {
+    switch (event.code) {
+      case 'ArrowLeft':
+      case 'KeyA':
+        controls.left = false;
+        break;
+      case 'ArrowRight':
+      case 'KeyD':
+        controls.right = false;
+        break;
+      default:
+        break;
+    }
+  });
+
+  canvas.addEventListener('pointerdown', (event) => {
+    if (!state.playing) return;
+    canvas.setPointerCapture?.(event.pointerId);
+    movePlayerToPointer(event);
+  });
+
+  canvas.addEventListener('pointermove', (event) => {
+    if (!state.playing) return;
+    if (event.pointerType === 'mouse' && event.buttons === 0) return;
+    movePlayerToPointer(event);
+  });
+
+  canvas.addEventListener('pointerup', (event) => {
+    canvas.releasePointerCapture?.(event.pointerId);
+  });
+}
+
+function startGame() {
+  state.playing = true;
+  state.gameOver = false;
+  state.score = 0;
+  state.level = 1;
+  state.lives = 3;
+  state.spawnTimer = 0;
+  state.newHighScoreThisRun = false;
+  items.length = 0;
+  floatingTexts.length = 0;
+  particles.length = 0;
+  player.x = canvas.width / 2;
+  player.dashTime = 0;
+  player.dashCooldown = 0.3;
+  player.shieldTime = 0;
+  player.trail.length = 0;
+
+  scoreEl.textContent = '0';
+  levelEl.textContent = '1';
+  livesEl.textContent = '3';
+  bestEl.textContent = state.highScore;
+  updateMessage('準備好追光冒險！祝你高分！', 2200);
+}
+
+function gameOver() {
+  state.gameOver = true;
+  state.playing = false;
+  updateMessage('遊戲結束！按 Enter 或 點擊「開始遊戲」重試。', 4000);
+  if (state.newHighScoreThisRun) {
+    if (storageAvailable) {
+      localStorage.setItem(STORAGE_KEY, String(state.highScore));
+    }
+    floatingTexts.push(createFloatingText('⭐ 新的最高分！ ⭐', canvas.width / 2, canvas.height / 2, '#ffd166'));
+  }
+}
+
+function dash() {
+  if (player.dashCooldown > 0 || player.dashTime > 0) return;
+  player.dashTime = 0.35;
+  player.dashCooldown = 1.6;
+  floatingTexts.push(createFloatingText('閃避疾跑！', player.x, player.y - 40, '#8ec5ff'));
+  spawnBurst(player.x, player.y + 20, '#79f2ff', 12);
+  updateMessage('疾跑啟動！掌握好距離～', 1500);
+}
+
+let lastTime = performance.now();
+
+function loop(timestamp) {
+  const delta = Math.min((timestamp - lastTime) / 1000, 0.035);
+  lastTime = timestamp;
+
+  update(delta);
+  draw();
+
+  requestAnimationFrame(loop);
+}
+
+function update(delta) {
+  updateStarfield(delta);
+
+  if (!state.playing) {
+    updateParticles(delta);
+    advanceFloatingTexts(floatingTexts, delta);
+    return;
+  }
+
+  const dashActive = player.dashTime > 0;
+  if (player.dashTime > 0) {
+    player.dashTime -= delta;
+    if (player.dashTime <= 0) {
+      player.dashTime = 0;
+      updateMessage('疾跑冷卻中…', 1200);
+    }
+  } else if (player.dashCooldown > 0) {
+    player.dashCooldown -= delta;
+    if (player.dashCooldown <= 0) {
+      player.dashCooldown = 0;
+      updateMessage('疾跑準備就緒！', 1400);
+      spawnBurst(player.x, player.y, '#ffb703', 8);
+    }
+  }
+
+  if (player.shieldTime > 0) {
+    player.shieldTime -= delta;
+    if (player.shieldTime <= 0) {
+      player.shieldTime = 0;
+      floatingTexts.push(createFloatingText('護盾消失', player.x, player.y - 50, '#ff595e'));
+    }
+  }
+
+  const playerSpeed = player.baseSpeed * (dashActive ? player.dashMultiplier : 1);
+  if (controls.left) {
+    player.x -= playerSpeed * delta;
+  }
+  if (controls.right) {
+    player.x += playerSpeed * delta;
+  }
+  player.x = clamp(player.x, player.width / 2 + 12, canvas.width - player.width / 2 - 12);
+
+  if (dashActive) {
+    player.trail.push({ x: player.x, y: player.y, alpha: 0.7 });
+    if (player.trail.length > 18) {
+      player.trail.shift();
+    }
+  } else if (player.trail.length > 0) {
+    player.trail.shift();
+  }
+
+  state.spawnTimer -= delta;
+  if (state.spawnTimer <= 0) {
+    spawnItem();
+    const interval = Math.max(0.35, 1.2 - state.level * 0.1);
+    state.spawnTimer = interval * (0.8 + Math.random() * 0.5);
+  }
+
+  for (let i = items.length - 1; i >= 0; i -= 1) {
+    const item = items[i];
+    item.y += item.speed * delta;
+    if (item.wobbleSpeed) {
+      item.wobblePhase += delta * item.wobbleSpeed;
+      item.x += Math.sin(item.wobblePhase) * item.wobbleRange * delta;
+    }
+
+    if (item.y - item.radius > canvas.height + 40) {
+      items.splice(i, 1);
+      continue;
+    }
+
+    if (collides(item, player)) {
+      items.splice(i, 1);
+      handleCollision(item);
+    }
+  }
+
+  updateParticles(delta);
+  advanceFloatingTexts(floatingTexts, delta);
+}
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  drawStarfield();
+
+  drawParticles();
+
+  for (const item of items) {
+    drawItem(item);
+  }
+
+  drawPlayer();
+
+  drawFloatingTexts();
+}
+
+function spawnItem() {
+  const random = Math.random();
+  const x = 60 + Math.random() * (canvas.width - 120);
+  const baseSpeed = 120 + state.level * 35;
+
+  if (random < 0.58) {
+    const isSilver = Math.random() < 0.22;
+    items.push({
+      type: isSilver ? 'silver-star' : 'gold-star',
+      x,
+      y: -20,
+      radius: isSilver ? 16 : 14,
+      speed: baseSpeed * (isSilver ? 1.2 : 1),
+      wobbleSpeed: 3 + Math.random() * 2,
+      wobblePhase: Math.random() * Math.PI * 2,
+      wobbleRange: 45,
+      value: isSilver ? 20 : 10,
+    });
+  } else if (random < 0.84) {
+    items.push({
+      type: 'void-orb',
+      x,
+      y: -30,
+      radius: 22,
+      speed: baseSpeed * 1.3,
+      wobbleSpeed: 1 + Math.random() * 1.5,
+      wobblePhase: Math.random() * Math.PI * 2,
+      wobbleRange: 70,
+    });
+  } else {
+    items.push({
+      type: 'shield-orb',
+      x,
+      y: -25,
+      radius: 18,
+      speed: baseSpeed * 0.9,
+      wobbleSpeed: 4,
+      wobblePhase: Math.random() * Math.PI * 2,
+      wobbleRange: 30,
+    });
+  }
+}
+
+function handleCollision(item) {
+  if (item.type === 'gold-star' || item.type === 'silver-star') {
+    state.score += item.value;
+    updateScoreDisplay();
+    floatingTexts.push(createFloatingText(`+${item.value}`, item.x, player.y - 20, '#ffe066'));
+    spawnBurst(item.x, item.y, item.type === 'silver-star' ? '#b5f5ff' : '#f3d34a', 14);
+    state.level = Math.min(15, 1 + Math.floor(state.score / 80));
+    levelEl.textContent = state.level;
+  } else if (item.type === 'shield-orb') {
+    const bonus = 30;
+    state.score += bonus;
+    updateScoreDisplay();
+    player.shieldTime = Math.min(player.shieldTime + 5, 8);
+    floatingTexts.push(createFloatingText('護盾加持 +5秒', item.x, player.y - 20, '#7dffb7'));
+    spawnBurst(item.x, item.y, '#72efdd', 16);
+    updateMessage('獲得護盾！暫時無敵！', 1800);
+  } else if (item.type === 'void-orb') {
+    if (player.shieldTime > 0) {
+      floatingTexts.push(createFloatingText('護盾抵禦！', player.x, player.y - 40, '#6afcff'));
+      spawnBurst(item.x, item.y, '#6afcff', 16);
+      state.score += 5;
+      updateScoreDisplay();
+    } else {
+      state.lives -= 1;
+      livesEl.textContent = state.lives;
+      floatingTexts.push(createFloatingText('被暗物質撞擊！', player.x, player.y - 50, '#ff6b6b'));
+      spawnBurst(item.x, item.y, '#ff4d6d', 20);
+      if (state.lives <= 0) {
+        gameOver();
+      }
+    }
+  }
+}
+
+function createFloatingText(text, x, y, color) {
+  return {
+    text,
+    x,
+    y,
+    color,
+    life: 1.2,
+  };
+}
+
+function drawFloatingTexts() {
+  for (const entry of floatingTexts) {
+    ctx.globalAlpha = Math.max(entry.life, 0);
+    ctx.fillStyle = entry.color;
+    ctx.font = '20px Nunito, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText(entry.text, entry.x, entry.y);
+  }
+  ctx.globalAlpha = 1;
+}
+
+function updateParticles(delta) {
+  for (let i = particles.length - 1; i >= 0; i -= 1) {
+    const particle = particles[i];
+    particle.x += particle.vx * delta;
+    particle.y += particle.vy * delta;
+    particle.life -= delta;
+    if (particle.life <= 0) {
+      particles.splice(i, 1);
+    }
+  }
+}
+
+function drawParticles() {
+  for (const particle of particles) {
+    ctx.globalAlpha = Math.max(particle.life, 0);
+    ctx.fillStyle = particle.color;
+    ctx.beginPath();
+    ctx.arc(particle.x, particle.y, particle.size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+}
+
+function spawnBurst(x, y, color, count) {
+  for (let i = 0; i < count; i += 1) {
+    const angle = Math.random() * Math.PI * 2;
+    const speed = 120 + Math.random() * 180;
+    particles.push({
+      x,
+      y,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed,
+      color,
+      size: 3 + Math.random() * 4,
+      life: 0.5 + Math.random() * 0.6,
+    });
+  }
+}
+
+function drawPlayer() {
+  ctx.save();
+  if (player.trail.length) {
+    for (let i = 0; i < player.trail.length; i += 1) {
+      const entry = player.trail[i];
+      ctx.globalAlpha = (i + 1) / player.trail.length * 0.4;
+      ctx.fillStyle = '#7a88ff';
+      ctx.beginPath();
+      ctx.ellipse(entry.x, entry.y + 8 + i * 3, player.width * 0.7, player.height, 0, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+  }
+
+  const gradient = ctx.createLinearGradient(player.x - player.width / 2, player.y, player.x + player.width / 2, player.y);
+  gradient.addColorStop(0, '#7f5af0');
+  gradient.addColorStop(0.5, '#2cb1ff');
+  gradient.addColorStop(1, '#ff8906');
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  drawRoundedRectPath(ctx, player.x - player.width / 2, player.y - player.height / 2, player.width, player.height, 16);
+  ctx.fill();
+
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.55)';
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
+  const cockpitX = player.x;
+  const cockpitY = player.y - 5;
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.85)';
+  ctx.beginPath();
+  ctx.ellipse(cockpitX, cockpitY, 16, 12, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  if (player.shieldTime > 0) {
+    const pulse = Math.sin(performance.now() / 120) * 0.1 + 0.9;
+    ctx.strokeStyle = `rgba(112, 255, 220, ${0.4 + Math.random() * 0.1})`;
+    ctx.lineWidth = 6;
+    ctx.beginPath();
+    ctx.arc(player.x, player.y, 54 * pulse, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawItem(item) {
+  if (item.type === 'gold-star' || item.type === 'silver-star') {
+    const gradient = ctx.createRadialGradient(item.x - 4, item.y - 4, 2, item.x, item.y, item.radius * 1.2);
+    if (item.type === 'silver-star') {
+      gradient.addColorStop(0, '#f1f7ff');
+      gradient.addColorStop(0.6, '#9be7ff');
+      gradient.addColorStop(1, 'rgba(155, 231, 255, 0)');
+    } else {
+      gradient.addColorStop(0, '#ffe066');
+      gradient.addColorStop(0.6, '#f79d65');
+      gradient.addColorStop(1, 'rgba(247, 157, 101, 0)');
+    }
+    ctx.fillStyle = gradient;
+    ctx.beginPath();
+    ctx.arc(item.x, item.y, item.radius * 1.2, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.save();
+    ctx.translate(item.x, item.y);
+    ctx.rotate(Math.sin(performance.now() / 200 + item.x) * 0.3);
+    ctx.fillStyle = item.type === 'silver-star' ? '#f1f7ff' : '#fcd34d';
+    ctx.beginPath();
+    for (let i = 0; i < 5; i += 1) {
+      const angle = (i / 5) * Math.PI * 2;
+      const outer = item.radius;
+      const inner = item.radius * 0.45;
+      ctx.lineTo(Math.cos(angle) * outer, Math.sin(angle) * outer);
+      ctx.lineTo(Math.cos(angle + Math.PI / 5) * inner, Math.sin(angle + Math.PI / 5) * inner);
+    }
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+  } else if (item.type === 'void-orb') {
+    const gradient = ctx.createRadialGradient(item.x - 6, item.y - 6, 1, item.x, item.y, item.radius * 1.3);
+    gradient.addColorStop(0, '#ff4d6d');
+    gradient.addColorStop(0.7, '#240046');
+    gradient.addColorStop(1, 'rgba(36, 0, 70, 0)');
+    ctx.fillStyle = gradient;
+    ctx.beginPath();
+    ctx.arc(item.x, item.y, item.radius * 1.3, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.strokeStyle = 'rgba(255, 82, 82, 0.6)';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(item.x, item.y, item.radius - 4, 0, Math.PI * 2);
+    ctx.stroke();
+  } else if (item.type === 'shield-orb') {
+    const gradient = ctx.createRadialGradient(item.x, item.y, 2, item.x, item.y, item.radius * 1.4);
+    gradient.addColorStop(0, '#9dffda');
+    gradient.addColorStop(0.6, '#72efdd');
+    gradient.addColorStop(1, 'rgba(114, 239, 221, 0)');
+    ctx.fillStyle = gradient;
+    ctx.beginPath();
+    ctx.arc(item.x, item.y, item.radius * 1.4, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.strokeStyle = 'rgba(114, 239, 221, 0.8)';
+    ctx.lineWidth = 2;
+    ctx.setLineDash([4, 6]);
+    ctx.beginPath();
+    ctx.arc(item.x, item.y, item.radius + 4, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.setLineDash([]);
+  }
+}
+
+function movePlayerToPointer(event) {
+  const rect = canvas.getBoundingClientRect();
+  const relativeX = ((event.clientX - rect.left) / rect.width) * canvas.width;
+  player.x = clamp(relativeX, player.width / 2 + 12, canvas.width - player.width / 2 - 12);
+}
+
+function updateStarfield(delta) {
+  for (const star of starfield) {
+    star.y += star.speed * delta;
+    star.x += Math.sin((performance.now() / 1000 + star.offset) * 2) * star.swing * delta * 20;
+    if (star.y > canvas.height + star.size) {
+      star.y = -star.size;
+      star.x = Math.random() * canvas.width;
+    }
+  }
+}
+
+function drawStarfield() {
+  for (const star of starfield) {
+    ctx.globalAlpha = star.opacity;
+    ctx.fillStyle = star.color;
+    ctx.beginPath();
+    ctx.arc(star.x, star.y, star.size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+}
+
+function drawRoundedRectPath(context, x, y, width, height, radius) {
+  const r = Math.min(radius, width / 2, height / 2);
+  if (context.roundRect) {
+    context.roundRect(x, y, width, height, r);
+    return;
+  }
+  context.moveTo(x + r, y);
+  context.lineTo(x + width - r, y);
+  context.quadraticCurveTo(x + width, y, x + width, y + r);
+  context.lineTo(x + width, y + height - r);
+  context.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  context.lineTo(x + r, y + height);
+  context.quadraticCurveTo(x, y + height, x, y + height - r);
+  context.lineTo(x, y + r);
+  context.quadraticCurveTo(x, y, x + r, y);
+}
+
+function updateScoreDisplay() {
+  scoreEl.textContent = state.score;
+  if (state.score > state.highScore) {
+    state.highScore = state.score;
+    state.newHighScoreThisRun = true;
+    bestEl.textContent = state.highScore;
+    if (storageAvailable) {
+      localStorage.setItem(STORAGE_KEY, String(state.highScore));
+    }
+  }
+}
+
+function updateMessage(text, duration = 1500) {
+  messageEl.textContent = text;
+  messageEl.classList.add('visible');
+  if (messageTimer) {
+    clearTimeout(messageTimer);
+  }
+  messageTimer = setTimeout(() => {
+    messageEl.classList.remove('visible');
+  }, duration);
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,138 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Nunito', 'PingFang TC', 'Microsoft JhengHei', sans-serif;
+  background: radial-gradient(circle at top, #12043b, #05020f 70%);
+  color: #f6f6ff;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.game-wrapper {
+  display: grid;
+  grid-template-columns: minmax(280px, 320px) minmax(480px, 1fr) minmax(240px, 300px);
+  gap: 1.5rem;
+  max-width: 1200px;
+  width: 100%;
+}
+
+.panel {
+  background: rgba(9, 7, 23, 0.72);
+  padding: 1.5rem;
+  border-radius: 18px;
+  border: 1px solid rgba(120, 126, 255, 0.2);
+  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.35);
+}
+
+h1 {
+  margin-top: 0;
+  font-size: 2.2rem;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+}
+
+h2 {
+  margin-top: 0;
+  font-size: 1.3rem;
+  letter-spacing: 1px;
+}
+
+p {
+  line-height: 1.6;
+}
+
+ul {
+  margin: 0.5rem 0 1.5rem;
+  padding-left: 1.2rem;
+  line-height: 1.6;
+}
+
+li {
+  margin-bottom: 0.3rem;
+}
+
+.primary {
+  background: linear-gradient(135deg, #5b7cff, #8c2bff);
+  border: none;
+  border-radius: 999px;
+  padding: 0.8rem 1.6rem;
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 1px;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.primary:hover,
+.primary:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(92, 91, 250, 0.35);
+}
+
+.game-area {
+  position: relative;
+}
+
+canvas {
+  width: 100%;
+  border-radius: 22px;
+  background: linear-gradient(180deg, rgba(4, 9, 37, 0.92), rgba(2, 2, 8, 0.9));
+  border: 1px solid rgba(120, 126, 255, 0.2);
+  box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.45);
+}
+
+.hud {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem 1rem;
+  padding: 1rem 1.2rem;
+  font-weight: 700;
+  text-shadow: 0 0 8px rgba(0, 255, 255, 0.4);
+}
+
+.message {
+  position: absolute;
+  left: 50%;
+  bottom: 1.4rem;
+  transform: translateX(-50%);
+  background: rgba(12, 9, 45, 0.7);
+  border: 1px solid rgba(88, 209, 255, 0.4);
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-align: center;
+  min-width: 200px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.message.visible {
+  opacity: 1;
+}
+
+.tips .emphasis {
+  color: #ffa933;
+  font-weight: 700;
+}
+
+@media (max-width: 1080px) {
+  .game-wrapper {
+    grid-template-columns: minmax(280px, 1fr);
+  }
+
+  .panel {
+    text-align: center;
+  }
+
+  .game-area {
+    order: 3;
+  }
+}


### PR DESCRIPTION
## Summary
- extract reusable helpers for collision, clamping, starfield creation, and floating-text updates into a dedicated module
- update the canvas game to consume the shared utilities via ES module imports and keep floating-text updates centralized
- switch the page script tag to module mode and add a Node test suite plus project metadata for running automated checks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8fad824288325a503dd137ee944f4