### PR TITLE
Add iPhone 18 promotional landing page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,350 @@
+:root {
+  color-scheme: dark;
+  --bg: #050505;
+  --panel: #0e0f15;
+  --panel-light: #151727;
+  --text: #f5f5f7;
+  --muted: #b1b6c5;
+  --accent: #7ef9ff;
+  --accent-2: #8b5cf6;
+  --accent-3: #f9a8d4;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'SF Pro Display', 'SF Pro Text', system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at top, #111322 0%, #050505 55%, #040404 100%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 96px;
+}
+
+.hero {
+  padding: 48px 8vw 0;
+}
+
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 0 32px;
+}
+
+.logo {
+  font-weight: 600;
+  letter-spacing: 0.2rem;
+  font-size: 1.1rem;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  font-size: 0.95rem;
+}
+
+.nav-links a {
+  color: var(--muted);
+}
+
+.nav-cta {
+  border: 1px solid transparent;
+  background: linear-gradient(120deg, var(--accent), var(--accent-2));
+  color: #060606;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.hero-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 48px;
+  align-items: center;
+  padding: 48px 0 64px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.4rem;
+  color: var(--accent);
+  font-size: 0.85rem;
+  margin-bottom: 16px;
+}
+
+.hero-content h1 {
+  font-size: clamp(2.8rem, 5vw, 4.6rem);
+  line-height: 1.05;
+  margin-bottom: 16px;
+}
+
+.hero-content h1 span {
+  display: block;
+  background: linear-gradient(120deg, var(--accent), var(--accent-3));
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.hero-description {
+  color: var(--muted);
+  line-height: 1.7;
+  font-size: 1rem;
+  max-width: 520px;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 16px;
+  margin: 24px 0 32px;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+.primary {
+  background: linear-gradient(120deg, var(--accent), var(--accent-2));
+  color: #030303;
+  padding: 14px 28px;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+}
+
+.ghost {
+  background: transparent;
+  border: 1px solid #2a2d3a;
+  color: var(--text);
+  padding: 14px 26px;
+  border-radius: 999px;
+}
+
+.hero-meta {
+  display: flex;
+  gap: 32px;
+  flex-wrap: wrap;
+  color: var(--muted);
+}
+
+.hero-meta h3 {
+  color: var(--text);
+  font-size: 1.2rem;
+}
+
+.hero-card {
+  background: linear-gradient(160deg, rgba(22, 25, 42, 0.9), rgba(10, 11, 19, 0.95));
+  border-radius: 32px;
+  padding: 32px;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(126, 249, 255, 0.15);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+}
+
+.hero-card-top {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.hero-ring {
+  width: 260px;
+  height: 260px;
+  margin: 40px auto;
+  border-radius: 50%;
+  border: 1px solid rgba(126, 249, 255, 0.3);
+  box-shadow: inset 0 0 30px rgba(126, 249, 255, 0.4), 0 0 80px rgba(139, 92, 246, 0.35);
+  position: relative;
+}
+
+.hero-ring::after {
+  content: '';
+  position: absolute;
+  inset: 16px;
+  border-radius: 50%;
+  border: 1px dashed rgba(249, 168, 212, 0.5);
+}
+
+.hero-stats {
+  display: flex;
+  justify-content: space-between;
+  text-align: center;
+  color: var(--muted);
+}
+
+.hero-stats strong {
+  display: block;
+  color: var(--text);
+  font-size: 1.2rem;
+}
+
+.section {
+  padding: 0 8vw;
+}
+
+.section-title {
+  margin-bottom: 32px;
+}
+
+.section-title p {
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.3rem;
+  font-size: 0.8rem;
+  margin-bottom: 12px;
+}
+
+.section-title h2 {
+  font-size: clamp(2rem, 4vw, 3rem);
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.card {
+  background: var(--panel);
+  border-radius: 24px;
+  padding: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+}
+
+.card h3 {
+  margin-bottom: 12px;
+  font-size: 1.2rem;
+}
+
+.card p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.specs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 40px;
+  align-items: center;
+  background: linear-gradient(120deg, rgba(126, 249, 255, 0.08), rgba(139, 92, 246, 0.12));
+  border-radius: 32px;
+  padding: 48px 8vw;
+  margin: 0 8vw;
+}
+
+.specs p {
+  color: var(--muted);
+  line-height: 1.7;
+  margin: 16px 0 24px;
+}
+
+.specs-list {
+  display: grid;
+  gap: 16px;
+}
+
+.spec-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-radius: 16px;
+  background: rgba(7, 7, 12, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.spec-item span {
+  color: var(--muted);
+}
+
+.experience {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.experience-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.experience-grid article {
+  background: linear-gradient(160deg, rgba(21, 23, 39, 0.9), rgba(10, 10, 18, 0.9));
+  padding: 24px;
+  border-radius: 24px;
+  border: 1px solid rgba(126, 249, 255, 0.1);
+}
+
+.experience-grid p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.cta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  background: var(--panel-light);
+  border-radius: 32px;
+  padding: 40px 8vw;
+  margin: 0 8vw;
+}
+
+.cta p {
+  color: var(--muted);
+  margin-top: 12px;
+}
+
+.footer {
+  text-align: center;
+  color: var(--muted);
+  padding: 32px 8vw 48px;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 720px) {
+  .nav {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero-meta {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .cta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,0 +1,16 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'iPhone 18 Pro | 宣傳網站',
+  description: 'iPhone 18 Pro 宣傳網站，呈現設計、效能與影像的全新突破。',
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="zh-Hant">
+      <body>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,0 +1,165 @@
+const highlights = [
+  {
+    title: '星曜鈦金屬機身',
+    description: '全新「星曜鈦」打造更輕盈機身，帶來宛如星際流光的質感。',
+  },
+  {
+    title: 'A19 Hyper 晶片',
+    description: '下一代 3 奈米架構，跨場景 AI 融合運算速度提升 45%。',
+  },
+  {
+    title: '超級視網膜 XDR 2.0',
+    description: '峰值亮度 3000 尼特，戶外強光下依然清晰震撼。',
+  },
+];
+
+const specs = [
+  { label: '螢幕', value: '6.8 吋超級視網膜 XDR 2.0' },
+  { label: '處理器', value: 'A19 Hyper · 16 核心神經引擎' },
+  { label: '相機', value: '48MP Ultra Fusion 三鏡頭' },
+  { label: '續航', value: '最長 32 小時影片播放' },
+  { label: '充電', value: 'MagSafe 30W 快充' },
+  { label: '連線', value: 'Wi-Fi 7 + 衛星通訊 2.0' },
+];
+
+const stories = [
+  {
+    title: '夜拍更純淨',
+    description: '全新光子引擎重構暗部細節，夜景噪點減少 60%。',
+  },
+  {
+    title: '空間錄影',
+    description: '空間影片升級 8K，戴上 Vision 裝置立即沉浸。',
+  },
+  {
+    title: '專屬 Apple Intelligence',
+    description: '端上運算個人化助理，隱私全面內建。',
+  },
+];
+
+export default function Home() {
+  return (
+    <div className="page">
+      <header className="hero">
+        <nav className="nav">
+          <div className="logo">Apple</div>
+          <div className="nav-links">
+            <a href="#highlights">亮點</a>
+            <a href="#specs">規格</a>
+            <a href="#experience">體驗</a>
+            <button className="nav-cta">立即預購</button>
+          </div>
+        </nav>
+
+        <div className="hero-content">
+          <div>
+            <p className="eyebrow">iPhone 18 Pro</p>
+            <h1>
+              讓未來
+              <span>親手掌握</span>
+            </h1>
+            <p className="hero-description">
+              全新 iPhone 18 Pro，以星曜鈦金屬、A19 Hyper 晶片與超級視網膜 XDR 2.0，
+              帶來超越想像的智慧體驗。
+            </p>
+            <div className="hero-actions">
+              <button className="primary">立即預購</button>
+              <button className="ghost">觀看發表會</button>
+            </div>
+            <div className="hero-meta">
+              <div>
+                <h3>9/20 起</h3>
+                <p>全球同步上市</p>
+              </div>
+              <div>
+                <h3>NT$43,900 起</h3>
+                <p>最高 36 期分期零利率</p>
+              </div>
+            </div>
+          </div>
+          <div className="hero-card">
+            <div className="hero-card-top">
+              <span>iPhone 18 Pro</span>
+              <span>星曜鈦</span>
+            </div>
+            <div className="hero-ring" />
+            <div className="hero-stats">
+              <div>
+                <strong>30%</strong>
+                <span>更輕盈</span>
+              </div>
+              <div>
+                <strong>45%</strong>
+                <span>AI 效能提升</span>
+              </div>
+              <div>
+                <strong>32hr</strong>
+                <span>續航</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section id="highlights" className="section">
+        <div className="section-title">
+          <p>新世代突破</p>
+          <h2>更薄、更快、更聰明</h2>
+        </div>
+        <div className="card-grid">
+          {highlights.map((item) => (
+            <article key={item.title} className="card">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section id="specs" className="section specs">
+        <div>
+          <h2>規格總覽</h2>
+          <p>
+            每一項細節都為最極致的體驗而打造，從顯示到續航都全面升級。
+          </p>
+          <button className="primary">探索完整規格</button>
+        </div>
+        <div className="specs-list">
+          {specs.map((spec) => (
+            <div key={spec.label} className="spec-item">
+              <span>{spec.label}</span>
+              <strong>{spec.value}</strong>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="experience" className="section experience">
+        <div className="section-title">
+          <p>沉浸體驗</p>
+          <h2>重塑你的創作方式</h2>
+        </div>
+        <div className="experience-grid">
+          {stories.map((story) => (
+            <article key={story.title}>
+              <h3>{story.title}</h3>
+              <p>{story.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="section cta">
+        <div>
+          <h2>準備好迎接 iPhone 18 Pro 嗎？</h2>
+          <p>加入預購名單，第一時間體驗未來。</p>
+        </div>
+        <button className="primary">加入預購名單</button>
+      </section>
+
+      <footer className="footer">
+        <p>© 2025 Apple Inc. 此為概念宣傳網站。</p>
+      </footer>
+    </div>
+  );
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "iphone-18-promo",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, static Next.js promotional landing page for an "iPhone 18 Pro" concept to showcase hero, highlights, specs, experience and CTA sections.
- Include a dark, responsive visual style and metadata so the site can be exported as a static site for deployment.

### Description
- Add page content and structure in `app/page.jsx` implementing hero, highlights, specs, experience, CTA and footer sections.
- Add global styles in `app/globals.css` to implement the dark visual theme, responsive layout and component styles.
- Add top-level layout and metadata in `app/layout.jsx` to wrap pages and import global styles.
- Add `next.config.js` with `output: 'export'` to configure Next.js for static export and add `package.json` with scripts and dependency versions (`next`, `react`, `react-dom`).

### Testing
- Attempted `npm install` in the workspace, which failed with an npm registry error (`403 Forbidden`), so the project build (`next build`) and runtime tests were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69893a4fcd0c83259e24e56cde2b193c)